### PR TITLE
travisのバッジurlを変更（masterブランチの状態に固定）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-BookShelf [![Build Status](https://travis-ci.org/to-sho-kan/bookshelf_proto.svg)](https://travis-ci.org/to-sho-kan/bookshelf_proto)
+BookShelf [![Build Status](https://travis-ci.org/to-sho-kan/bookshelf_proto.svg)](https://travis-ci.org/to-sho-kan/bookshelf_proto.svg?branch=master)
 =========
 ローカルコミュニティ向け・書籍管理アプリのプロトタイプ
 


### PR DESCRIPTION
最新のtravis結果が表示されてしまっていたので、masterブランチに対して行ったCIの結果を表示するように変更
