### PR TITLE
vendor/bundle配下をrubocopにチェックさせない

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
     - 'db/**/*'
     - 'config/**/*'
     - 'ngapp/**/*'
+    - 'vendor/bundle/**/*'
 
 # # Use UTF-8 as the source file encoding.
 # Encoding:


### PR DESCRIPTION
bundle install 時に --path vendor/bundle した環境で rubocopを実行すると 
vendor/bundle配下もチェックして壮大にこけちゃうのでここはチェック対象外にしました。

@n-gondo123 @tohruyamamoto 